### PR TITLE
specify a minimum Perl version

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,6 +8,7 @@ my $builder = Module::Build->new(
     dist_author       => 'Mithun Ayachit <mithun@cpan.org>',
     dist_version_from => 'lib/URI/Encode.pm',
     requires          => {
+        'perl'       => '5.8.1', # for Unicode support 
         'Test::More' => 0,
         'version'    => 0,
         'Encode'     => '2.12',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,11 +3,12 @@ use warnings;
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
-    NAME          => 'URI::Encode',
-    AUTHOR        => 'Mithun Ayachit <mithun@cpan.org>',
-    VERSION_FROM  => 'lib/URI/Encode.pm',
-    ABSTRACT_FROM => 'lib/URI/Encode.pm',
-    PL_FILES      => {},
+    NAME             => 'URI::Encode',
+    AUTHOR           => 'Mithun Ayachit <mithun@cpan.org>',
+    VERSION_FROM     => 'lib/URI/Encode.pm',
+    ABSTRACT_FROM    => 'lib/URI/Encode.pm',
+    PL_FILES         => {},
+    MIN_PERL_VERSION => '5.8.1',
     PREREQ_PM     => {
         'Test::More' => 0,
         'version'    => 0,


### PR DESCRIPTION
Thanks for contributing URI::Encode. Here's a small patch to declare that that minimum supported Perl version is Perl 5.8.1, often considered a minimum version for sane UTF-8 support.

   Mark
